### PR TITLE
Send request/notifications to lsps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,9 @@ use serde_json::Value;
 
 pub enum StartLspServer {}
 
-impl Notification for StartLspServer {
+impl Request for StartLspServer {
     type Params = StartLspServerParams;
+    type Result = StartLspServerResult;
     const METHOD: &'static str = "host/startLspServer";
 }
 
@@ -19,6 +20,16 @@ pub struct StartLspServerParams {
     pub server_args: Vec<String>,
     pub document_selector: DocumentSelector,
     pub options: Option<Value>,
+}
+
+/// The id of a started Language Server.  
+/// This is used to reference the server in future requests.
+pub type LspId = u64;
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartLspServerResult {
+    pub id: LspId,
 }
 
 pub enum ExecuteProcess {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,48 @@ pub struct StartLspServerResult {
     pub id: LspId,
 }
 
+pub struct SendLspNotification {}
+
+impl Notification for SendLspNotification {
+    type Params = SendLspNotificationParams;
+    const METHOD: &'static str = "host/sendLspNotification";
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLspNotificationParams {
+    /// Id of the LSP server the notification should be sent to
+    pub id: LspId,
+    pub method: String,
+    pub params: Value,
+}
+
+/// Send an LSP request to a started LSP server.  
+/// This does not include the `id` of the request, because that is handled by the client editor to
+/// avoid collisions.
+pub struct SendLspRequest {}
+
+impl Request for SendLspRequest {
+    type Params = SendLspRequestParams;
+    type Result = SendLspRequestResult;
+    const METHOD: &'static str = "host/sendLspRequest";
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLspRequestParams {
+    /// Id of the LSP server the notification should be sent to
+    pub id: LspId,
+    pub method: String,
+    pub params: Value,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLspRequestResult {
+    pub result: Value,
+}
+
 pub enum ExecuteProcess {}
 
 impl Request for ExecuteProcess {


### PR DESCRIPTION
This adds the types for sending requests/notifications to language servers.  
This also changes start lsp server to be a request rather than a notification.

- We could make `LspId` a more general string type, like jsonrpc ids. 
  - I don't think this is really needed. At worst we force potential implementators of the plugin server protocol to keep a map of some incrementing id to their true internal id.
- Minor: could make `LspId` a `struct LspId(pub u64);` instead.

- As mentioned in the comment, we don't include an id in the send-lsp-request request because there would be room for collisions with ids that lapce internally uses. 
  - The only thing this would disallow is communicating information with the id, but I don't think any lsp does this.. and they really shouldn't
- 